### PR TITLE
RNMT-4535 disable daemon 9.0.x

### DIFF
--- a/bin/templates/cordova/lib/config/GradlePropertiesParser.js
+++ b/bin/templates/cordova/lib/config/GradlePropertiesParser.js
@@ -31,7 +31,7 @@ class GradlePropertiesParser {
     constructor (platformDir) {
         this._defaults = {
             // 10 seconds -> 6 seconds
-            'org.gradle.daemon': 'true',
+            'org.gradle.daemon': 'false',
 
             // to allow dex in process
             'org.gradle.jvmargs': '-Xmx2048m',


### PR DESCRIPTION
This PR disables the gradle daemon

The fix for projects not being able to have its name starting with a number applied in #2 and #1 is not necessary, due to this cordova-android version (9.0.0) already containing said fix

