### PR TITLE
RNMT-5258 ::: MABS 8 ::: Fix android apps not building with & in the name

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -21,6 +21,7 @@ var path = require('path');
 var fs = require('fs-extra');
 var utils = require('./utils');
 var check_reqs = require('./check_reqs');
+const { escape } = require('lodash');
 var ROOT = path.join(__dirname, '..');
 const { createEditor } = require('properties-parser');
 
@@ -255,7 +256,7 @@ exports.create = function (project_path, config, options, events) {
             fs.ensureDirSync(activity_dir);
             fs.copySync(path.join(project_template_dir, 'Activity.java'), activity_path);
             utils.replaceFileContents(activity_path, /__ACTIVITY__/, safe_activity_name);
-            utils.replaceFileContents(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, project_name);
+            utils.replaceFileContents(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, escape(project_name));
             utils.replaceFileContents(activity_path, /__ID__/, package_name);
 
             var manifest = new AndroidManifest(path.join(project_template_dir, 'AndroidManifest.xml'));

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
     "is-path-inside": "^3.0.3",
+    "lodash": "^4.17.21",
     "nopt": "^5.0.0",
     "properties-parser": "^0.3.1",
     "semver": "^7.3.5",

--- a/spec/unit/create.spec.js
+++ b/spec/unit/create.spec.js
@@ -275,6 +275,38 @@ describe('create', function () {
                 });
             });
 
+            it('should interpolate the escaped project name into strings.xml', () => {
+                var passed = true;
+                config_mock.name.and.returnValue('<Incredible&App>');
+                passed = passed && create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, '&lt;Incredible&amp;App&gt;');
+                });
+                config_mock.name.and.returnValue('& 12XPTO & W');
+                passed = passed && create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, '&amp; 12XPTO &amp; W');
+                });
+                config_mock.name.and.returnValue('Strange $ Combinaned # App &');
+                passed = passed && create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, 'Strange $ Combinaned # App &amp;');
+                });
+                config_mock.name.and.returnValue('$KUH% I*& $)OFNlkfn$');
+                passed = passed && create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, '$KUH% I*&amp; $)OFNlkfn$');
+                });
+                config_mock.name.and.returnValue('&B&B');
+                passed = passed && create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, '&amp;B&amp;B');
+                });
+                return passed;
+            });
+
+            it('should interpolate the project name with arabic chars into strings.xml', () => {
+                config_mock.name.and.returnValue('غظضذخثتشرقصفعسنملكيطحزوهدبأ');
+                return create.create(project_path, config_mock, {}, events_mock).then(() => {
+                    expect(utils.replaceFileContents).toHaveBeenCalledWith(path.join(app_path, 'res', 'values', 'strings.xml'), /__NAME__/, 'غظضذخثتشرقصفعسنملكيطحزوهدبأ');
+                });
+            });
+
             it('should copy template scripts into generated project', () => {
                 return create.create(project_path, config_mock, {}, events_mock).then(() => {
                     expect(create.copyScripts).toHaveBeenCalledWith(project_path);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes android apps with & in the name

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-5258
<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [X] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Test added in cordova-android repo
```
  create
    validateProjectName helper method
      happy path
        ✓ should interpolate the escaped project name into strings.xml (0 sec)
```
