### PR TITLE
RNMT-5392 Change default value of FilterTouchesWhenObscured preference to true

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -186,7 +186,7 @@ public class CordovaActivity extends AppCompatActivity {
         appView.getView().setLayoutParams(new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
-        appView.getView().setFilterTouchesWhenObscured(preferences.getBoolean("FilterTouchesWhenObscured", false));
+        appView.getView().setFilterTouchesWhenObscured(preferences.getBoolean("FilterTouchesWhenObscured", true));
 
         setContentView(appView.getView());
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR changes the default value of `FilterTouchesWhenObscured` preference to `true`, which means that, by default, it  prevents touches when the app is obscured, and avoids the app being flagged by Google Play Store as a security issue.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-5392
<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [x] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Screenshots

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [X] Code follows code style of this project
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly