### PR TITLE
RNMT-6064 Ensure Kotlin JVM target is 1.8

### DIFF
--- a/templates/project/app/build.gradle
+++ b/templates/project/app/build.gradle
@@ -252,6 +252,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    if (cordovaConfig.IS_GRADLE_PLUGIN_KOTLIN_ENABLED) {
+        kotlinOptions {
+            jvmTarget = '1.8'
+        }
+    }
+
     if (cdvReleaseSigningPropertiesFile) {
         signingConfigs {
             release {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Using AGP 8 as default will require JDK 17 which causes JVM target incompatibility when building an application using both Java and Kotlin source code, failing the build.

<img width="1920" alt="image" src="https://github.com/OutSystems/cordova-android/assets/996955/3e6d5eb4-1cf1-4f59-b262-422ba30b9494">


### Description
<!-- Describe your changes in detail -->
Ensuring Kotlin's JVM target to 1.8 overcomes the issue. Check the commit message for more information.

References https://outsystemsrd.atlassian.net/browse/RNMT-6064

### Testing
<!-- Please describe in detail how you tested your changes. -->


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
