### PR TITLE
RNMT-6283 Remove eval usages to fix possibility of unsafe-eval violation

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -222,11 +222,7 @@ function buildPayload (payload, message) {
 // Processes a single message, as encoded by NativeToJsMessageQueue.java.
 function processMessage (message) {
     var firstChar = message.charAt(0);
-    if (firstChar === 'J') {
-        // This is deprecated on the .java side. It doesn't work with CSP enabled.
-        // eslint-disable-next-line no-eval
-        eval(message.slice(1));
-    } else if (firstChar === 'S' || firstChar === 'F') {
+    if (firstChar === 'S' || firstChar === 'F') {
         var success = firstChar === 'S';
         var keepCallback = message.charAt(1) === '1';
         var spaceIdx = message.indexOf(' ', 2);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The `sendJavascript()` deprecated method sends a message from the Native to JS that will result in the usage of the eval function, which triggers an `unsafe-eval` violation when CSP is enabled with that option enabled.

<!-- If it fixes an open issue, please link to the issue here. -->
Contributes to https://outsystemsrd.atlassian.net/browse/RNMT-6283

### Description
<!-- Describe your changes in detail -->
Removes all `eval` usages (there is only one) from the JS code.
This represents a BREAKING CHANGE since it makes the deprecated `sendJavascript` method to not work for communications between the Native and the JS side.

### Testing
<!-- Please describe in detail how you tested your changes. -->

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
