### PR TITLE
RDMR-1284 add EdgeToEdgeGlyphTheme preference to SystemBarPlugin

### DIFF
--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -50,6 +50,7 @@ public class SystemBarPlugin extends CordovaPlugin {
     private int overrideStatusBarBackgroundColor = INVALID_COLOR;
 
     private boolean canEdgeToEdge = false;
+    private String edgeToEdgeGlyphTheme = null;
 
     @Override
     protected void pluginInitialize() {
@@ -57,6 +58,7 @@ public class SystemBarPlugin extends CordovaPlugin {
         resources = context.getResources();
         canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
                 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
+        edgeToEdgeGlyphTheme = preferences.getString("EdgeToEdgeGlyphTheme", null);
     }
 
     @Override
@@ -238,7 +240,10 @@ public class SystemBarPlugin extends CordovaPlugin {
 
         // Automatically set the font and icon color of the system bars based on background color.
         boolean isStatusBarBackgroundColorLight;
-        if(bgColor == Color.TRANSPARENT) {
+        if (canEdgeToEdge && edgeToEdgeGlyphTheme != null
+                && edgeToEdgeGlyphTheme.matches("(?i)(dark|light)")) {
+            isStatusBarBackgroundColorLight = edgeToEdgeGlyphTheme.equalsIgnoreCase("dark");
+        } else if(bgColor == Color.TRANSPARENT) {
             isStatusBarBackgroundColorLight = isColorLight(getUiModeColor());
         } else {
             isStatusBarBackgroundColorLight = isColorLight(bgColor);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Android status bar glyph color was relative only to the system color scheme when in edge to edge, not the application color.  This change also doesn't determine the glyph color from the application color, but exposes a mechanism for developers to set it themselves.


### Description
<!-- Describe your changes in detail -->
new Cordova preference `EdgeToEdgeGlyphTheme` to allow developers to set the glyph color to light or dark.  Only effects apps when edge to edge is enabled.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manually tested.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
