### PR TITLE
feat(android): enable edge-to-edge support for Android 9 and above

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -119,8 +119,7 @@ public class CordovaActivity extends AppCompatActivity {
         // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
         loadConfig();
 
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
 
         String logLevel = preferences.getString("loglevel", "ERROR");
         LOG.setLogLevel(logLevel);

--- a/framework/src/org/apache/cordova/SystemBarPlugin.java
+++ b/framework/src/org/apache/cordova/SystemBarPlugin.java
@@ -55,8 +55,7 @@ public class SystemBarPlugin extends CordovaPlugin {
     protected void pluginInitialize() {
         context = cordova.getContext();
         resources = context.getResources();
-        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false)
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM;
+        canEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
     }
 
     @Override


### PR DESCRIPTION
The goal here is to add back an approximation of the old preference StatusBarOverlaysWebview. We did this by removing the API 35, android 15, version gate on the AndroidEdgeToEdge preference, allowing edge-to-edge mode to be enabled on Android 9+ (API 28). We can do this now because AndroidEdgeToEdge is still opt in, so we can enforce an OutSystemsUI upgrade on users who choose to opt in. We couldn't do this before when it was originally going to be the default to be opted in, as that would force a breaking change on users.

### Platforms affected
Android


### Motivation and Context
This change was added in because we previously made the decision to remove statusBarOverlaysWebview. It turns out our customers did not want that, so we are adding in a feature to get similar functionality back.


### Description
At the top


### Testing
I used the local version in an app, along with an updated insets injector, here are the results ->
https://outsystemsrd.atlassian.net/wiki/spaces/RDMBLVS/pages/6156877852/Edge+To+Edge+with+StatusBarOverlaysWebview+functionality+Added+Back+In


### Checklist
- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary -> Not yet, but it is in the ac, and will be done before anything is released. So I am going to mark the check as a "will be done" instead of an "is done"

